### PR TITLE
Cache openstacksdk Connections to avoid leaking memory

### DIFF
--- a/ironic_inspector/test/unit/test_common_ironic.py
+++ b/ironic_inspector/test/unit/test_common_ironic.py
@@ -32,8 +32,12 @@ class TestGetClientBase(base.BaseTest):
         ir_utils.reset_ironic_session()
 
     def test_get_client(self, mock_connection, mock_session):
-        ir_utils.get_client()
-        self.assertEqual(1, mock_session.call_count)
+        for i in range(3):
+            cli = ir_utils.get_client()
+            self.assertIs(mock_connection.return_value.baremetal, cli)
+        mock_session.assert_called_once_with('ironic')
+        mock_connection.assert_called_once_with(
+            session=mock_session.return_value, oslo_conf=ir_utils.CONF)
 
 
 class TestGetIpmiAddress(base.BaseTest):

--- a/releasenotes/notes/sdk-2-leak-500f3669afb6713e.yaml
+++ b/releasenotes/notes/sdk-2-leak-500f3669afb6713e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes memory leak with openstacksdk 2.0 and newer. This version requires
+    connections to be explicitly closed, otherwise they stay in memory forever.


### PR DESCRIPTION
The current code never closes connection. Newer openstacksdk versions
register Connection.close with the atexit mechanism, so any connections
that are not explicitly closed stay in memory forever.

Change-Id: I18bbb460cbaa4f58f9e736c071571c38ced35892
(cherry picked from commit 48a3bf605b1d110b505d30e208b6ea64a121f848)
